### PR TITLE
Support custom call paths such as `Computed.templateString`

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,12 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    // Add options here
+    emberComputedTemplateString: {
+      replaceCallPaths: [
+        'Computed.templateString',
+        'Nested.Computed.templateString'
+      ]
+    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -7,12 +7,13 @@ module.exports = {
   name: 'ember-computed-template-string',
   included: function(app) {
     this._super.included(...arguments);
+
     app.options = app.options || {};
     app.options.babel = app.options.babel || {};
     app.options.babel.plugins = app.options.babel.plugins || [];
 
     if (!this._registeredWithBabel) {
-      app.options.babel.plugins.push(ComputedTemplateStringTransform());
+      app.options.babel.plugins.push(ComputedTemplateStringTransform(app.options.emberComputedTemplateString));
       this._registeredWithBabel = true;
     }
   }

--- a/plugins/computed-template-string-transform.js
+++ b/plugins/computed-template-string-transform.js
@@ -1,10 +1,12 @@
 'use strict';
-
 let Parser = require('ember-computed-template-string-parser');
-let ComputedTemplateStringTransform = function() {
+
+let ComputedTemplateStringTransform = function(options) {
+  let configuredReplaceCallPaths = options.replaceCallPaths || [];
+
   return function(babel) {
     let types = babel.types;
-    let importedComputedTemplateStringModuleName;
+    let importedComputedTemplateStringModuleName; //`computedTemplateString` from `import computedTemplateString from 'ember-computed-template-string';`
 
     return new babel.Transformer('simple-transform', {
       ImportDeclaration: function(node, parent, scope, file) {
@@ -16,9 +18,16 @@ let ComputedTemplateStringTransform = function() {
         }
       },
       CallExpression: function(node, parent, scope, file) {
-        let isMemberExpression = node.callee.type === 'MemberExpression';
         let isIdentifier = node.callee.type === 'Identifier';
-        if(isIdentifier && node.callee.name === importedComputedTemplateStringModuleName) {
+        let isImportedTemplateString = isIdentifier && node.callee.name === importedComputedTemplateStringModuleName;
+
+        let isConfiguredCallPath = false;
+        if(node.callee.type === 'MemberExpression') {
+          let callPath = getCallPath(node.callee);
+          isConfiguredCallPath = configuredReplaceCallPaths.indexOf(callPath) > -1;
+        }
+
+        if(isImportedTemplateString || isConfiguredCallPath) {
           let template = node.arguments[0].value;
           let parser = new Parser(template);
           return this.replaceWithSourceString(parser.toComputedPropertyString());
@@ -27,4 +36,18 @@ let ComputedTemplateStringTransform = function() {
     });
   }
 };
+
+function getCallPath(node) {
+  let leftSide = '';
+  if(node.object.type === 'Identifier') {
+    leftSide = node.object.name;
+  } else {
+    if(node.object.type === 'MemberExpression') {
+      leftSide = getCallPath(node.object);
+    };
+  }
+
+  return `${leftSide}.${node.property.name}`;
+}
+
 module.exports = ComputedTemplateStringTransform;

--- a/tests/unit/computed-template-string-test.js
+++ b/tests/unit/computed-template-string-test.js
@@ -1,9 +1,8 @@
 import Em from 'ember';
 import computedTemplateString from 'ember-computed-template-string';
-
 import { module, test } from 'qunit';
 
-module("Computed.templateString");
+module("Computed template string with an import");
 
 var Person = Em.Object.extend({
   name: 'Alex',
@@ -18,7 +17,6 @@ var Person = Em.Object.extend({
   withDoubleQuote: computedTemplateString('Double quote in literal: " and in property: ${name}'),
 });
 
-
 test('A template with two properties', function(assert) {
   var person = Person.create({ name: 'Alex', age: 2 });
   assert.equal(person.get('greeting'), 'Hello Alex, you are 2 years old');
@@ -26,7 +24,7 @@ test('A template with two properties', function(assert) {
   person.setProperties({ name: 'Ben', age: 1 });
   assert.equal(person.get('greeting'), 'Hello Ben, you are 1 years old');
 });
-//
+
 test('A template with a nested property', function(assert) {
   var person = Person.create();
   assert.equal(person.get('nested'), 'the path is /home, ok?');

--- a/tests/unit/custom-replace-call-paths-test.js
+++ b/tests/unit/custom-replace-call-paths-test.js
@@ -1,0 +1,25 @@
+import Em from 'ember';
+import { module, test } from 'qunit';
+import computedTemplateString from 'ember-computed-template-string';
+
+//these are configured in `ember-cli-build.js`
+let Computed = { templateString: computedTemplateString };
+let Nested = { Computed: Computed };
+
+module("Computed template string with `replaceCallPaths` configuration");
+
+var Person = Em.Object.extend({
+  name: 'Ben',
+  greeting1: Computed.templateString('Hi ${name}'),
+  greeting2: Nested.Computed.templateString('Hello ${name}')
+});
+
+test('A simple template', function(assert) {
+  var person = Person.create({ name: 'Ben' });
+  assert.equal(person.get('greeting1'), 'Hi Ben');
+  assert.equal(person.get('greeting2'), 'Hello Ben');
+
+  person.setProperties({ name: 'Alex' });
+  assert.equal(person.get('greeting1'), 'Hi Alex');
+  assert.equal(person.get('greeting2'), 'Hello Alex');
+});


### PR DESCRIPTION
/fyi @serenaf this allows a custom matching function to be provided to the addon and will allow use to match on custom namespaces such as `Computed.templateString('...')`.

This will allow us to replace our internal implementation with this open source addon without needing to update any consuming code
