### PR TITLE
Change node engine to be >= 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": "",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4.0.0"
   },
   "author": "Intercom Engineering",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": "",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 5.0.0"
   },
   "author": "Intercom Engineering",
   "license": "Apache-2.0",


### PR DESCRIPTION
The node land code depends on string templates, let, spread operator, etc. and won't work in <= 5.0.0
